### PR TITLE
feat: support wandb

### DIFF
--- a/src/wav2vec_toolkit/finetune.py
+++ b/src/wav2vec_toolkit/finetune.py
@@ -10,3 +10,47 @@ from wav2vec_toolkit.finetune import finetune
 
 finetune(base_model="facebook/wav2vec-xlsr", dataset="common_voice", language="fr", max_epochs=100)
 """
+
+import os
+from dataclasses import dataclass, field
+from typing import Optional
+from transformers import HfArgumentParser
+import wandb
+
+
+@dataclass
+class FakeArguments:
+    epochs: Optional[int] = field(
+        default=1, metadata={"help": "Fake number of epochs"}
+    )
+    learning_rate: Optional[float] = field(
+        default=0.001, metadata={"help": "Fake learning rate"}
+    )
+    dropout: Optional[float] = field(
+        default=0.5, metadata={"help": "Fake learning rate"}
+    output_dir: Optional[str]=field(
+        default='', metadata={"help": "Fake output directory"}
+    )
+
+def main():
+    parser=HfArgumentParser((FakeArguments,))
+
+    # start a new run and log all args
+    args=parser.parse_args()
+    wandb.init(config=args, project='xlsr')
+
+    # main loop
+    fake_args, = parser.parse_args_into_dataclasses()
+    import random, time
+    time.sleep(5)
+    test_wer=random.random()
+
+    # logging will be automatically done by Trainer
+    wandb.log({'test/wer': test_wer})
+
+    # log model files as artifact
+    artifact=wandb.Artifact(name=f"model-{wandb.run.id}", type="model", metadata={'wer': test_wer})
+    for f in Path(training_args.output_dir).iterdir():
+        if f.is_file():
+            artifact.add_file(str(f))
+    wandb.run.log_artifact(artifact)


### PR DESCRIPTION
I've added the barebones for W&B support.

Few notes:

* I've not built the training logic because I feel it's a separate issue. My own structure follows closely `run_common_voice` with a few tweaks but I see we already created a few utils in this repo.
* I'm not using `WANDB_LOG_MODEL` and instead manually log all the required files because it would only log the model files while we also want the preprocecssing files (which are not saved with `trainer.save_model()`)
* For doing a parameter search using W&B sweeps, we will just need a yaml [like this](https://github.com/borisdayma/xlsr-sweeps/blob/master/sweep.yaml)
* I didn't add `wandb` into the requirements (should it be dev only) as I'm not sure if this repo will be mainly for training or also for evaluating (I imagine evaluating would be directly through `transformers`)